### PR TITLE
Fix Assimp import

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -179,6 +179,9 @@ class LibnameConan(ConanFile):
         tools.replace_in_file(os.path.join(self._source_subfolder, "src", "MagnumPlugins", "AssimpImporter", "CMakeLists.txt"),
             "target_link_libraries(AssimpImporter PUBLIC Magnum::Trade Assimp::Assimp",
             "target_link_libraries(AssimpImporter PUBLIC Magnum::Trade CONAN_PKG::assimp")
+        tools.replace_in_file(os.path.join(self._source_subfolder, "src", "MagnumPlugins", "AssimpImporter", "CMakeLists.txt"),
+            "find_package(Assimp REQUIRED)",
+            "")
 
     def _configure_cmake(self):
         cmake = CMake(self)


### PR DESCRIPTION
This package will fail to compile, because `find_package(Assimp REQUIRED)` will fail with conan and is not needed due to targets.

```
-- Selecting Windows SDK version 10.0.17763.0 to target Windows 10.0.19042.
-- The C compiler identification is MSVC 19.16.27045.0
-- The CXX compiler identification is MSVC 19.16.27045.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.16.27023/bin/Hostx86/x64/cl.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Tools/MSVC/14.16.27023/bin/Hostx86/x64/cl.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Conan: called by CMake conan helper
-- Conan: called inside local cache
-- Conan: Adjusting output directories
-- Conan: Using cmake targets configuration
-- Library MagnumText-d found F:/.conan/3a16a8/1/lib/MagnumText-d.lib
-- Library MagnumDebugTools-d found F:/.conan/3a16a8/1/lib/MagnumDebugTools-d.lib
-- Library MagnumGlfwApplication-d found F:/.conan/3a16a8/1/lib/MagnumGlfwApplication-d.lib
-- Library MagnumTextureTools-d found F:/.conan/3a16a8/1/lib/MagnumTextureTools-d.lib
-- Library MagnumShaders-d found F:/.conan/3a16a8/1/lib/MagnumShaders-d.lib
-- Library MagnumPrimitives-d found F:/.conan/3a16a8/1/lib/MagnumPrimitives-d.lib
-- Library MagnumMeshTools-d found F:/.conan/3a16a8/1/lib/MagnumMeshTools-d.lib
-- Library MagnumTrade-d found F:/.conan/3a16a8/1/lib/MagnumTrade-d.lib
-- Library MagnumSceneGraph-d found F:/.conan/3a16a8/1/lib/MagnumSceneGraph-d.lib
-- Library MagnumGL-d found F:/.conan/3a16a8/1/lib/MagnumGL-d.lib
-- Library Magnum-d found F:/.conan/3a16a8/1/lib/Magnum-d.lib
-- Library OpenGL32.lib not found in package, might be system one
-- Library IrrXML found F:/conan-cache/pcpd/.conan/data/assimp/4.1.0/camposs/stable/package/009a50ddeb47afbc9361cbc63650560c127e1234/lib/IrrXML.lib
-- Library assimp found F:/conan-cache/pcpd/.conan/data/assimp/4.1.0/camposs/stable/package/009a50ddeb47afbc9361cbc63650560c127e1234/lib/assimp.lib
-- Library assimp-vc140-mt found F:/conan-cache/pcpd/.conan/data/assimp/4.1.0/camposs/stable/package/009a50ddeb47afbc9361cbc63650560c127e1234/lib/assimp-vc140-mt.lib
-- Library CorradeTestSuite-d found F:/.conan/8cb5dd/1/lib/CorradeTestSuite-d.lib
-- Library CorradePluginManager-d found F:/.conan/8cb5dd/1/lib/CorradePluginManager-d.lib
-- Library CorradeInterconnect-d found F:/.conan/8cb5dd/1/lib/CorradeInterconnect-d.lib
-- Library CorradeUtility-d found F:/.conan/8cb5dd/1/lib/CorradeUtility-d.lib
-- Library glfw3 found F:/conan-cache/pcpd/.conan/data/glfw/3.3/camposs/stable/package/8cf01e2f50fcd6b63525e70584df0326550364e1/lib/glfw3.lib
-- Library zlibd found F:/conan-cache/pcpd/.conan/data/zlib/1.2.11/camposs/stable/package/ff82a1e70ba8430648a79986385b20a3648f8c19/lib/zlibd.lib
-- Conan: Adjusting default RPATHs Conan policies
-- Conan: Adjusting language standard
-- Found Corrade: F:/.conan/8cb5dd/1/include  found components: Containers rc Utility
-- Found Magnum: F:/.conan/3a16a8/1/include
-- Found Git: C:/Program Files/Git/cmd/git.exe (found version "2.34.1.windows.1")
-- Found Corrade: F:/.conan/8cb5dd/1/include  found components: Containers rc Utility PluginManager
-- Found Magnum: F:/.conan/3a16a8/1/include  found components: Trade AnyImageImporter
CMake Error at C:/Program Files/CMake/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Assimp (missing: ASSIMP_LIBRARY)
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.22/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
  source_subfolder/modules/FindAssimp.cmake:87 (find_package_handle_standard_args)
  source_subfolder/src/MagnumPlugins/AssimpImporter/CMakeLists.txt:28 (find_package)


-- Configuring incomplete, errors occurred!
See also "F:/.conan/bba4f6/1/build_subfolder/CMakeFiles/CMakeOutput.log".
magnum-plugins/2020.06@camposs/stable:
magnum-plugins/2020.06@camposs/stable: ERROR: Package '88dda0a31a2087e7b1084996e98d5c1f89a8c66c' build failed
magnum-plugins/2020.06@camposs/stable: WARN: Build folder F:\.conan\bba4f6\1
ERROR: magnum-plugins/2020.06@camposs/stable: Error in build() method, line 208
        cmake = self._configure_cmake()
while calling '_configure_cmake', line 202
        cmake.configure(build_folder=self._build_subfolder)
        ConanException: Error 1 while executing cd F:\.conan\bba4f6\1\build_subfolder && cmake -G "Visual Studio 15 2017 Win64" -DCONAN_LINK_RUNTIME="/MDd" -DCONAN_IN_LOCAL_CACHE="ON" -DCONAN_COMPILER="Visual Studio" -DCONAN_COMPILER_VERSION="15" -DCONAN_CXX_FLAGS="/MP12" -DCONAN_C_FLAGS="/MP12" -DBUILD_SHARED_LIBS="OFF" -DCMAKE_INSTALL_PREFIX="F:\.conan\45370d\1" -DCMAKE_INSTALL_BINDIR="bin" -DCMAKE_INSTALL_SBINDIR="bin" -DCMAKE_INSTALL_LIBEXECDIR="bin" -DCMAKE_INSTALL_LIBDIR="lib" -DCMAKE_INSTALL_INCLUDEDIR="include" -DCMAKE_INSTALL_OLDINCLUDEDIR="include" -DCMAKE_INSTALL_DATAROOTDIR="share" -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY="ON" -DCONAN_EXPORTED="1" -DBUILD_PLUGINS_STATIC="OFF" -DSHARED="OFF" -DWITH_ASSIMPIMPORTER="ON" -DWITH_DDSIMPORTER="OFF" -DWITH_DEVILIMAGEIMPORTER="OFF" -DWITH_DRFLACAUDIOIMPORTER="OFF" -DWITH_DRWAVAUDIOIMPORTER="OFF" -DWITH_FAAD2AUDIOIMPORTER="OFF" -DWITH_FREETYPEFONT="OFF" -DWITH_HARFBUZZFONT="OFF" -DWITH_JPEGIMAGECONVERTER="OFF" -DWITH_JPEGIMPORTER="OFF" -DWITH_MINIEXRIMAGECONVERTER="OFF" -DWITH_OPENDDL="OFF" -DWITH_OPENGEXIMPORTER="OFF" -DWITH_PNGIMAGECONVERTER="OFF" -DWITH_PNGIMPORTER="OFF" -DWITH_STANFORDIMPORTER="OFF" -DWITH_STBIMAGECONVERTER="OFF" -DWITH_STBIMAGEIMPORTER="OFF" -DWITH_STBTRUETYPEFONT="OFF" -DWITH_STBVORBISAUDIOIMPORTER="OFF" -DWITH_STLIMPORTER="OFF" -DWITH_TINYGLTFIMPORTER="OFF" -DLIB_SUFFIX="" -DBUILD_STATIC="ON" -DBUILD_STATIC_PIC="None" -Wno-dev F:\.conan\bba4f6\1
```